### PR TITLE
Json fixes

### DIFF
--- a/src/lib/json.cpp
+++ b/src/lib/json.cpp
@@ -40,6 +40,12 @@ void Json::read(const string &content) {
 	} else if (firstChar == '"') {
 		this->type = JsonType::String;
 		this->stringValue = getInsideChunk(content);
+		// Now "un-escape" the quote characters
+		size_t index = stringValue->find("\\\"");
+		while (index != string::npos) {
+			stringValue->replace(index, 2, "\"");
+			index = stringValue->find("\\\"", index);
+		}
 	} else if (isNumber(firstChar)) {
 		this->type = JsonType::Number;
 		this->numberValue = stringToUnsignedLong(content);

--- a/src/lib/json.cpp
+++ b/src/lib/json.cpp
@@ -70,12 +70,7 @@ void Json::readObject(const string &content) {
 		string memberName = innerContent.substr(previousIndex, index - previousIndex);
 		previousIndex = index + 1;
 
-		char nextChar = innerContent.at(previousIndex);
-		if (nextChar == '{' || nextChar == '[') {
-			index = findEnclosingIndex(innerContent, previousIndex) + 1;
-		} else {
-			index = innerContent.find(',', previousIndex);
-		}
+		index = findEnclosingIndex(innerContent, previousIndex) + 1;
 
 		string memberContent = innerContent.substr(previousIndex, index - previousIndex);
 		previousIndex = index + 1;

--- a/src/lib/parseHelpers.h
+++ b/src/lib/parseHelpers.h
@@ -5,10 +5,26 @@
 #include <sstream>
 
 static inline char getClosingSymbol(const char openingSymbol);
+static inline bool isNumber(char character);
 
 static inline int findEnclosingIndex(const std::string &original, int index) {
 	const char start = original[index];
+
+	// Numbers are special! oh my! They end on the first non-numerical char
+	if (isNumber(start)) {
+		// Numbers end on the first non-numerical char
+		while (isNumber(original[++index]));
+
+		return index - 1;
+	}
+
 	const char end = getClosingSymbol(start);
+	// If they're the same we don't need to worry about nesting
+	if (start == end) {
+		return original.find(start, index + 1);
+	}
+
+	// Otherwise we might get some nasty stuff like {{{}{}}{}}.
 	int level = 1;
 	while (level > 0) {
 		const char nextChar = original[++index];

--- a/src/lib/parseHelpers.h
+++ b/src/lib/parseHelpers.h
@@ -21,7 +21,14 @@ static inline int findEnclosingIndex(const std::string &original, int index) {
 	const char end = getClosingSymbol(start);
 	// If they're the same we don't need to worry about nesting
 	if (start == end) {
-		return original.find(start, index + 1);
+		int end = original.find(start, index + 1);
+
+		// But we still have to ignore escaped characters
+		while (original.at(end - 1) == '\\') {
+			end = original.find(start, end + 1);
+		}
+
+		return end;
 	}
 
 	// Otherwise we might get some nasty stuff like {{{}{}}{}}.

--- a/tests/lib/jsonTest.cpp
+++ b/tests/lib/jsonTest.cpp
@@ -339,6 +339,16 @@ void JsonTest::stringWithCommas() {
 	checkString("is it, like, true?", json.getMember("is it, like, true?"), "Well, certainly!", "is it, like, true?");
 }
 
+void JsonTest::stringWithEscapedQuotes() {
+	const string content = "{\"a\":\"\\\"b\\\"\"}";
+
+	Json json;
+	json.read(content);
+
+	checkObject("root", &json, 1);
+	checkString("a", json.getMember("a"), "\"b\"", "a");
+}
+
 // Private helper methods
 void JsonTest::checkString(const std::string &tag, const Lib::Json *json, const std::string &value, const char *name) {
 	CPPUNIT_ASSERT_MESSAGE(tag + " should not be null", json != NULL);

--- a/tests/lib/jsonTest.cpp
+++ b/tests/lib/jsonTest.cpp
@@ -326,6 +326,19 @@ void JsonTest::simplifiedRealData() {
 	checkString("3rdElement3rdMember", thirdElement->members[2], "( 1.)", "special");
 }
 
+void JsonTest::stringWithCommas() {
+	string content = "{\"Commas\":\"I have, you know, some commas\",\"is it, like, true?\":\"Well, certainly!\"}";
+
+	Json json;
+	json.read(content);
+
+	CPPUNIT_ASSERT_EQUAL(JsonType::Object, json.type);
+	CPPUNIT_ASSERT_EQUAL(2, (int)json.members.size());
+
+	checkString("Commas", json.getMember("Commas"), "I have, you know, some commas", "Commas");
+	checkString("is it, like, true?", json.getMember("is it, like, true?"), "Well, certainly!", "is it, like, true?");
+}
+
 // Private helper methods
 void JsonTest::checkString(const std::string &tag, const Lib::Json *json, const std::string &value, const char *name) {
 	CPPUNIT_ASSERT_MESSAGE(tag + " should not be null", json != NULL);

--- a/tests/lib/jsonTest.h
+++ b/tests/lib/jsonTest.h
@@ -29,6 +29,9 @@ class JsonTest : public CppUnit::TestFixture {
 	CPPUNIT_TEST(objectWithArrayWithObjectWithArrayWithObject);
 	CPPUNIT_TEST(simplifiedRealData);
 
+	// Regression tests
+	CPPUNIT_TEST(stringWithCommas);
+
 	CPPUNIT_TEST_SUITE_END();
 public:
 	void emptyObject();
@@ -50,6 +53,9 @@ public:
 
 	void objectWithArrayWithObjectWithArrayWithObject();
 	void simplifiedRealData();
+
+	// Regression tests
+	void stringWithCommas();
 
 private:
 	void checkString(const std::string&, const Lib::Json*, const std::string&, const char* = NULL);

--- a/tests/lib/jsonTest.h
+++ b/tests/lib/jsonTest.h
@@ -31,6 +31,7 @@ class JsonTest : public CppUnit::TestFixture {
 
 	// Regression tests
 	CPPUNIT_TEST(stringWithCommas);
+	CPPUNIT_TEST(stringWithEscapedQuotes);
 
 	CPPUNIT_TEST_SUITE_END();
 public:
@@ -56,6 +57,7 @@ public:
 
 	// Regression tests
 	void stringWithCommas();
+	void stringWithEscapedQuotes();
 
 private:
 	void checkString(const std::string&, const Lib::Json*, const std::string&, const char* = NULL);


### PR DESCRIPTION
Fix two JSON parsing bugs, both with new unit tests for regression.

Both are to do with strings: one is for commas, and the other is for escaped quotes.
